### PR TITLE
fix(ci): fix Claude workflow permissions and playwright tools

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,16 +19,21 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
       - name: Project Setup
         run: |
           npm run setup
@@ -39,14 +44,14 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          
+
           custom_instructions: |
             The project is already set up with all dependencies installed.
-            The server is alreadt running at localhost:3000. Logs from it
-            are beign written to logs.txt. If needed, you can query the
-            db with the 'sqlite3' cli. If needed, yse the mcp_playwright
+            The server is already running at localhost:3000. Logs from it
+            are being written to logs.txt. If needed, you can query the
+            db with the 'sqlite3' cli. Use the mcp__playwright__*
             set of tools to launch a browser and interact with the app.
-          
+
           mcp_config: |
             {
               "mcpServers": {
@@ -60,5 +65,5 @@ jobs:
                 }
               }
             }
-            
-          allowed_tools: "Bash(npm:*),Bash(sqlite3:*),mcp__playwright__browser_snapshot,mcp__playwright__browser_click,..."
+
+          allowed_tools: "Bash(npm:*),Bash(sqlite3:*),mcp__playwright__browser_snapshot,mcp__playwright__browser_click,mcp__playwright__browser_navigate,mcp__playwright__browser_type,mcp__playwright__browser_take_screenshot,mcp__playwright__browser_fill_form,mcp__playwright__browser_select_option,mcp__playwright__browser_hover,mcp__playwright__browser_drag,mcp__playwright__browser_press_key,mcp__playwright__browser_wait_for,mcp__playwright__browser_evaluate,mcp__playwright__browser_network_requests,mcp__playwright__browser_console_messages,mcp__playwright__browser_tabs,mcp__playwright__browser_close,mcp__playwright__browser_resize,mcp__playwright__browser_handle_dialog,mcp__playwright__browser_navigate_back,mcp__playwright__browser_run_code,mcp__playwright__browser_file_upload"


### PR DESCRIPTION
## Summary

- Fix `contents`, `pull-requests` and `issues` permissions from `read` to `write` so Claude can commit and comment
- Add `actions/setup-node@v4` step with Node 20 and npm cache
- List all Playwright MCP tools explicitly (replacing the `...` placeholder)
- Fix typos in `custom_instructions`

## Test plan

- [ ] Open an issue with `@claude` and ask it to interact with the UI via browser
- [ ] Verify Claude can comment on the issue
- [ ] Verify Claude can commit changes if needed