### PR TITLE
fix(ci): fix Claude workflow — correct input names and permissions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -45,14 +45,14 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          custom_instructions: |
+          prompt: |
             The project is already set up with all dependencies installed.
             The server is already running at localhost:3000. Logs from it
             are being written to logs.txt. If needed, you can query the
             db with the 'sqlite3' cli. Use the mcp__playwright__*
             set of tools to launch a browser and interact with the app.
 
-          mcp_config: |
+          settings: |
             {
               "mcpServers": {
                 "playwright": {
@@ -63,7 +63,32 @@ jobs:
                     "localhost:3000;cdn.tailwindcss.com;esm.sh"
                   ]
                 }
+              },
+              "permissions": {
+                "allow": [
+                  "Bash(npm:*)",
+                  "Bash(sqlite3:*)",
+                  "mcp__playwright__browser_snapshot",
+                  "mcp__playwright__browser_click",
+                  "mcp__playwright__browser_navigate",
+                  "mcp__playwright__browser_type",
+                  "mcp__playwright__browser_take_screenshot",
+                  "mcp__playwright__browser_fill_form",
+                  "mcp__playwright__browser_select_option",
+                  "mcp__playwright__browser_hover",
+                  "mcp__playwright__browser_drag",
+                  "mcp__playwright__browser_press_key",
+                  "mcp__playwright__browser_wait_for",
+                  "mcp__playwright__browser_evaluate",
+                  "mcp__playwright__browser_network_requests",
+                  "mcp__playwright__browser_console_messages",
+                  "mcp__playwright__browser_tabs",
+                  "mcp__playwright__browser_close",
+                  "mcp__playwright__browser_resize",
+                  "mcp__playwright__browser_handle_dialog",
+                  "mcp__playwright__browser_navigate_back",
+                  "mcp__playwright__browser_run_code",
+                  "mcp__playwright__browser_file_upload"
+                ]
               }
             }
-
-          allowed_tools: "Bash(npm:*),Bash(sqlite3:*),mcp__playwright__browser_snapshot,mcp__playwright__browser_click,mcp__playwright__browser_navigate,mcp__playwright__browser_type,mcp__playwright__browser_take_screenshot,mcp__playwright__browser_fill_form,mcp__playwright__browser_select_option,mcp__playwright__browser_hover,mcp__playwright__browser_drag,mcp__playwright__browser_press_key,mcp__playwright__browser_wait_for,mcp__playwright__browser_evaluate,mcp__playwright__browser_network_requests,mcp__playwright__browser_console_messages,mcp__playwright__browser_tabs,mcp__playwright__browser_close,mcp__playwright__browser_resize,mcp__playwright__browser_handle_dialog,mcp__playwright__browser_navigate_back,mcp__playwright__browser_run_code,mcp__playwright__browser_file_upload"


### PR DESCRIPTION
## Summary

- Fix permissions: `contents`, `pull-requests`, `issues` de `read` → `write`
- Add `actions/setup-node@v4` con Node 20
- Reemplazar inputs inválidos por los correctos:
  - `custom_instructions` → `prompt`
  - `mcp_config` → `settings` (con `mcpServers` y `permissions.allow`)
  - `allowed_tools` → eliminado, tools configurados via `settings.permissions.allow`
- Corregir typos en instrucciones

## Test plan

- [ ] Abrir issue con `@claude` y pedirle que interactúe con el browser
- [ ] Verificar que no aparece el warning de inputs inválidos en los logs
- [ ] Verificar que Playwright MCP está disponible en el job